### PR TITLE
BUG: Remove parameter from bet2 execution

### DIFF
--- a/NeosegPipeline/DtiRegistration.cxx
+++ b/NeosegPipeline/DtiRegistration.cxx
@@ -105,7 +105,7 @@ void DtiRegistration::skullStripb0()
    m_inputs.insert("outbase", outbase_path); 
    m_outputs.insert("b0Mask", b0Mask_path);
    m_outputs.insert("strippedb0", strippedb0_path); 
-   m_argumentsList << "bet2" << "b0Nifti" << "outbase" << "'-m'"<< "b0Mask";
+   m_argumentsList << "bet2" << "b0Nifti" << "outbase" << "'-m'";
    execute();
 
    m_unnecessaryFiles << b0Mask_path;


### PR DESCRIPTION
Recent version of bet2 does not expect a filename after the flag '-m'